### PR TITLE
Add quaternion to cf tf

### DIFF
--- a/launch/dwm_loc.launch
+++ b/launch/dwm_loc.launch
@@ -1,25 +1,29 @@
 <launch>
   <rosparam command="load" file="$(find bitcraze_lps_estimator)/data/anchor_pos.yaml" />
 
-  <node name="log_range" pkg="bitcraze_lps_estimator" type="log_range.py" />
-  <node name="lps_pf" pkg="bitcraze_lps_estimator" type="lps_pf.py" />
-  <node name="lps_viz" pkg="bitcraze_lps_estimator" type="lps_viz.py" />
-
   <node name="rviz" pkg="rviz" type="rviz"
         args="-d $(find bitcraze_lps_estimator)/data/rvizconfig.rviz"/>
 
   <node pkg="tf" type="static_transform_publisher" name="link1_broadcaster"
         args="1 0 0 0 0 0 1 world lps 100" />
 
-  <node pkg="crazyflie_driver" type="crazyflie_add" name="crazyflie_add" output="screen">
-    <param name="uri" value="$(arg uri)" />
-    <param name="tf_prefix" value="crazyflie" />
-    <rosparam>
-      genericLogTopics: ["log_ranges"]
-      genericLogTopicFrequencies: [100]
-      genericLogTopic_log_ranges_Variables: ["ranging.distance1", "ranging.distance2", "ranging.distance3", "ranging.distance4", "ranging.distance5", "ranging.distance6", "ranging.state"]
-    </rosparam>
-  </node>
+  <group ns="crazyflie">
+    <node pkg="crazyflie_driver" type="crazyflie_add" name="crazyflie_add" output="screen">
+      <param name="uri" value="$(arg uri)" />
+      <param name="tf_prefix" value="crazyflie" />
+      <rosparam>
+        genericLogTopics: ["log_ranges"]
+        genericLogTopicFrequencies: [100]
+        genericLogTopic_log_ranges_Variables: ["ranging.distance1", "ranging.distance2", "ranging.distance3", "ranging.distance4", "ranging.distance5", "ranging.distance6", "ranging.state"]
+      </rosparam>
+
+    </node>
+
+    <node name="log_range" pkg="bitcraze_lps_estimator" type="log_range.py" />
+    <node name="lps_pf" pkg="bitcraze_lps_estimator" type="lps_pf.py" />
+    <node name="lps_viz" pkg="bitcraze_lps_estimator" type="lps_viz.py" />
+  </group>
+
 
   <include file="$(find crazyflie_driver)/launch/crazyflie_server.launch" />
 </launch>

--- a/launch/dwm_loc_ekf_hover.launch
+++ b/launch/dwm_loc_ekf_hover.launch
@@ -21,9 +21,10 @@
       <param name="uri" value="$(arg uri)" />
       <param name="tf_prefix" value="crazyflie" />
       <rosparam>
-        genericLogTopics: ["log_kfpos", "log_ranges"]
-        genericLogTopicFrequencies: [30, 30]
+        genericLogTopics: ["log_kfpos", "log_kfqt", "log_ranges"]
+        genericLogTopicFrequencies: [30, 30, 30]
         genericLogTopic_log_kfpos_Variables: ["kalman.stateX", "kalman.stateY", "kalman.stateZ"]
+        genericLogTopic_log_kfqt_Variables: ["kalman.q0", "kalman.q1", "kalman.q2", "kalman.q3"]
         genericLogTopic_log_ranges_Variables: ["ranging.distance1", "ranging.distance2", "ranging.distance3", "ranging.distance4", "ranging.distance5", "ranging.distance6", "ranging.state"]
       </rosparam>
     </node>

--- a/launch/dwm_loc_ekf_multi_hover.launch
+++ b/launch/dwm_loc_ekf_multi_hover.launch
@@ -26,9 +26,10 @@
       <param name="uri" value="$(arg uri0)" />
       <param name="tf_prefix" value="crazyflie0" />
       <rosparam>
-        genericLogTopics: ["log_kfpos"]
-        genericLogTopicFrequencies: [30]
+        genericLogTopics: ["log_kfpos", "log_kfqt"]
+        genericLogTopicFrequencies: [30, 30]
         genericLogTopic_log_kfpos_Variables: ["kalman.stateX", "kalman.stateY", "kalman.stateZ"]
+        genericLogTopic_log_kfqt_Variables: ["kalman.q0", "kalman.q1", "kalman.q2", "kalman.q3"]
       </rosparam>
     </node>
 
@@ -65,9 +66,10 @@
       <param name="uri" value="$(arg uri1)" />
       <param name="tf_prefix" value="crazyflie1" />
       <rosparam>
-        genericLogTopics: ["log_kfpos"]
-        genericLogTopicFrequencies: [30]
+        genericLogTopics: ["log_kfpos", "log_kfqt"]
+        genericLogTopicFrequencies: [30, 30]
         genericLogTopic_log_kfpos_Variables: ["kalman.stateX", "kalman.stateY", "kalman.stateZ"]
+        genericLogTopic_log_kfqt_Variables: ["kalman.q0", "kalman.q1", "kalman.q2", "kalman.q3"]
       </rosparam>
     </node>
 

--- a/launch/dwm_loc_lms.launch
+++ b/launch/dwm_loc_lms.launch
@@ -2,25 +2,27 @@
 <launch>
   <rosparam command="load" file="$(find bitcraze_lps_estimator)/data/anchor_pos.yaml" />
 
-  <node name="log_range" pkg="bitcraze_lps_estimator" type="log_range.py" />
-  <node name="lps_lms" pkg="bitcraze_lps_estimator" type="lps_lms.py" />
-  <node name="lps_viz" pkg="bitcraze_lps_estimator" type="lps_viz.py" />
-
   <node name="rviz" pkg="rviz" type="rviz"
         args="-d $(find bitcraze_lps_estimator)/data/rvizconfig.rviz"/>
 
   <node pkg="tf" type="static_transform_publisher" name="link1_broadcaster"
         args="1 0 0 0 0 0 1 world lps 100" />
 
-  <node pkg="crazyflie_driver" type="crazyflie_add" name="crazyflie_add" output="screen">
-    <param name="uri" value="$(arg uri)" />
-    <param name="tf_prefix" value="crazyflie" />
-    <rosparam>
-      genericLogTopics: ["log_ranges"]
-      genericLogTopicFrequencies: [100]
-      genericLogTopic_log_ranges_Variables: ["ranging.distance1", "ranging.distance2", "ranging.distance3", "ranging.distance4", "ranging.distance5", "ranging.distance6", "ranging.state"]
-    </rosparam>
-  </node>
+  <group ns="crazyflie">
+    <node pkg="crazyflie_driver" type="crazyflie_add" name="crazyflie_add" output="screen">
+      <param name="uri" value="$(arg uri)" />
+      <param name="tf_prefix" value="crazyflie" />
+      <rosparam>
+        genericLogTopics: ["log_ranges"]
+        genericLogTopicFrequencies: [100]
+        genericLogTopic_log_ranges_Variables: ["ranging.distance1", "ranging.distance2", "ranging.distance3", "ranging.distance4", "ranging.distance5", "ranging.distance6", "ranging.state"]
+      </rosparam>
+    </node>
+
+    <node name="log_range" pkg="bitcraze_lps_estimator" type="log_range.py" />
+    <node name="lps_lms" pkg="bitcraze_lps_estimator" type="lps_lms.py" />
+    <node name="lps_viz" pkg="bitcraze_lps_estimator" type="lps_viz.py" />
+  </group>
 
   <include file="$(find crazyflie_driver)/launch/crazyflie_server.launch" />
 </launch>

--- a/launch/dwm_loc_lms_hover.launch
+++ b/launch/dwm_loc_lms_hover.launch
@@ -9,10 +9,6 @@
 
   <rosparam command="load" file="$(find bitcraze_lps_estimator)/data/anchor_pos.yaml" />
 
-  <node name="log_range" pkg="bitcraze_lps_estimator" type="log_range.py" />
-  <node name="lps_lms" pkg="bitcraze_lps_estimator" type="lps_lms.py" />
-  <node name="lps_viz" pkg="bitcraze_lps_estimator" type="lps_viz.py" />
-
   <node name="rviz" pkg="rviz" type="rviz"
         args="-d $(find bitcraze_lps_estimator)/data/rvizconfig.rviz"/>
 
@@ -47,6 +43,10 @@
       <param name="y" value="$(arg y)" />
       <param name="z" value="$(arg z)" />
     </node>
+
+    <node name="log_range" pkg="bitcraze_lps_estimator" type="log_range.py" />
+    <node name="lps_lms" pkg="bitcraze_lps_estimator" type="lps_lms.py" />
+    <node name="lps_viz" pkg="bitcraze_lps_estimator" type="lps_viz.py" />
 
   </group>
 

--- a/launch/dwm_loc_lms_teleop.launch
+++ b/launch/dwm_loc_lms_teleop.launch
@@ -9,10 +9,6 @@
 
   <rosparam command="load" file="$(find bitcraze_lps_estimator)/data/anchor_pos.yaml" />
 
-  <node name="log_range" pkg="bitcraze_lps_estimator" type="log_range.py" />
-  <node name="lps_lms" pkg="bitcraze_lps_estimator" type="lps_lms.py" />
-  <node name="lps_viz" pkg="bitcraze_lps_estimator" type="lps_viz.py" />
-
   <node name="rviz" pkg="rviz" type="rviz"
         args="-d $(find bitcraze_lps_estimator)/data/rvizconfig.rviz"/>
 
@@ -37,6 +33,10 @@
 
     <node name="crazyflie_demo_controller" pkg="crazyflie_demo" type="controller.py" output="screen">
     </node>
+
+    <node name="log_range" pkg="bitcraze_lps_estimator" type="log_range.py" />
+    <node name="lps_lms" pkg="bitcraze_lps_estimator" type="lps_lms.py" />
+    <node name="lps_viz" pkg="bitcraze_lps_estimator" type="lps_viz.py" />
 
   </group>
 

--- a/launch/dwm_loc_pf_hover.launch
+++ b/launch/dwm_loc_pf_hover.launch
@@ -9,10 +9,6 @@
 
   <rosparam command="load" file="$(find bitcraze_lps_estimator)/data/anchor_pos.yaml" />
 
-  <node name="log_range" pkg="bitcraze_lps_estimator" type="log_range.py" />
-  <node name="lps_pf" pkg="bitcraze_lps_estimator" type="lps_pf.py" output="screen"/>
-  <node name="lps_viz" pkg="bitcraze_lps_estimator" type="lps_viz.py" />
-
   <node name="rviz" pkg="rviz" type="rviz"
         args="-d $(find bitcraze_lps_estimator)/data/rvizconfig_with_goal.rviz"/>
 
@@ -47,6 +43,10 @@
       <param name="y" value="$(arg y)" />
       <param name="z" value="$(arg z)" />
     </node>
+
+    <node name="log_range" pkg="bitcraze_lps_estimator" type="log_range.py" />
+    <node name="lps_pf" pkg="bitcraze_lps_estimator" type="lps_pf.py" output="screen"/>
+    <node name="lps_viz" pkg="bitcraze_lps_estimator" type="lps_viz.py" />
 
   </group>
 

--- a/launch/dwm_loc_pf_teleop.launch
+++ b/launch/dwm_loc_pf_teleop.launch
@@ -9,10 +9,6 @@
 
   <rosparam command="load" file="$(find bitcraze_lps_estimator)/data/anchor_pos.yaml" />
 
-  <node name="log_range" pkg="bitcraze_lps_estimator" type="log_range.py" />
-  <node name="lps_lms" pkg="bitcraze_lps_estimator" type="lps_lms.py" />
-  <node name="lps_viz" pkg="bitcraze_lps_estimator" type="lps_viz.py" />
-
   <node name="rviz" pkg="rviz" type="rviz"
         args="-d $(find bitcraze_lps_estimator)/data/rvizconfig.rviz"/>
 
@@ -37,6 +33,10 @@
 
     <node name="crazyflie_demo_controller" pkg="crazyflie_demo" type="controller.py" output="screen">
     </node>
+
+    <node name="log_range" pkg="bitcraze_lps_estimator" type="log_range.py" />
+    <node name="lps_lms" pkg="bitcraze_lps_estimator" type="lps_lms.py" />
+    <node name="lps_viz" pkg="bitcraze_lps_estimator" type="lps_viz.py" />
 
   </group>
 

--- a/launch/dwm_zmq.launch
+++ b/launch/dwm_zmq.launch
@@ -1,10 +1,12 @@
 <launch>
   <rosparam command="load" file="$(find bitcraze_lps_estimator)/data/anchor_pos.yaml" />
 
-  <node name="lps_pf" pkg="bitcraze_lps_estimator" type="lps_pf.py" />
-  <node name="zmq_range" pkg="bitcraze_lps_estimator" type="zmq_range.py" />
-  <node name="pos_zmq" pkg="bitcraze_lps_estimator" type="pos_zmq.py" />
-  <node name="lps_viz" pkg="bitcraze_lps_estimator" type="lps_viz" />
+  <group ns="crazyflie">
+    <node name="lps_pf" pkg="bitcraze_lps_estimator" type="lps_pf.py" />
+    <node name="zmq_range" pkg="bitcraze_lps_estimator" type="zmq_range.py" />
+    <node name="pos_zmq" pkg="bitcraze_lps_estimator" type="pos_zmq.py" />
+    <node name="lps_viz" pkg="bitcraze_lps_estimator" type="lps_viz" />
+  </group>
 
   <node name="rviz" pkg="rviz" type="rviz"
          args="-d $(find bitcraze_lps_estimator)/data/rvizconfig.rviz" />

--- a/scripts/log_range.py
+++ b/scripts/log_range.py
@@ -25,6 +25,7 @@ if __name__ == "__main__":
 
     ranging_pub = rospy.Publisher("ranging", RangeArray, queue_size=10)
 
-    rospy.Subscriber(rospy.get_namespace()+"log_ranges", GenericLogData, callback)
+    rospy.Subscriber(rospy.get_namespace()+"log_ranges",
+            GenericLogData, callback)
 
     rospy.spin()

--- a/scripts/log_range.py
+++ b/scripts/log_range.py
@@ -26,6 +26,6 @@ if __name__ == "__main__":
     ranging_pub = rospy.Publisher("ranging", RangeArray, queue_size=10)
 
     rospy.Subscriber(rospy.get_namespace()+"log_ranges",
-            GenericLogData, callback)
+                     GenericLogData, callback)
 
     rospy.spin()

--- a/scripts/log_range.py
+++ b/scripts/log_range.py
@@ -25,6 +25,6 @@ if __name__ == "__main__":
 
     ranging_pub = rospy.Publisher("ranging", RangeArray, queue_size=10)
 
-    rospy.Subscriber("/crazyflie/log_ranges", GenericLogData, callback)
+    rospy.Subscriber(rospy.get_namespace()+"log_ranges", GenericLogData, callback)
 
     rospy.spin()

--- a/scripts/lps_ekf_bridge.py
+++ b/scripts/lps_ekf_bridge.py
@@ -44,6 +44,7 @@ def callback_pos(data):
     point = ps.pose.position
     position_pub.publish(point)
 
+
 def callback_qt(data):
     ps.pose.orientation.w = data.values[0]
     ps.pose.orientation.x = data.values[1]
@@ -54,9 +55,9 @@ if __name__ == "__main__":
     rospy.init_node('lps_ekf_bridge')
 
     pose_pub = rospy.Publisher(rospy.get_namespace() + "pose",
-            PoseStamped, queue_size=10)
+                               PoseStamped, queue_size=10)
     position_pub = rospy.Publisher(rospy.get_namespace() + "position",
-            Point, queue_size=10)
+                                   Point, queue_size=10)
 
     # Set anchor position according to the position setup in ROS
     rospy.wait_for_service('update_params')
@@ -66,7 +67,8 @@ if __name__ == "__main__":
 
     n_anchors = rospy.get_param("n_anchors")
     for i in range(n_anchors):
-        position = rospy.get_param(rospy.get_namespace()+"anchor{}_pos".format(i))
+        position = rospy.get_param(rospy.get_namespace() +
+                                   "anchor{}_pos".format(i))
         rospy.loginfo("Anchor {} at {}".format(i, position))
         name = rospy.get_namespace()+"anchorpos/anchor{}".format(i)
         rospy.set_param(name + "x", position[0])

--- a/scripts/lps_ekf_bridge.py
+++ b/scripts/lps_ekf_bridge.py
@@ -21,6 +21,7 @@ ps.pose.position.x = 0
 ps.pose.position.y = 0
 ps.pose.position.z = 0
 
+
 def callback_pos(data):
     ps.pose.position.x = data.values[0]
     ps.pose.position.y = data.values[1]
@@ -31,12 +32,13 @@ def callback_pos(data):
     pose_pub.publish(ps)
 
     br = tf.TransformBroadcaster()
-    br.sendTransform((ps.pose.position.x, ps.pose.position.y, ps.pose.position.z),
-                     (ps.pose.orientation.x, ps.pose.orientation.y,
-                         ps.pose.orientation.z, ps.pose.orientation.w),
-                     rospy.Time.now(),
-                     rospy.get_namespace() + "base_link",
-                     "world")
+    br.sendTransform(
+            (ps.pose.position.x, ps.pose.position.y, ps.pose.position.z),
+            (ps.pose.orientation.x, ps.pose.orientation.y,
+                ps.pose.orientation.z, ps.pose.orientation.w),
+            rospy.Time.now(),
+            rospy.get_namespace() + "base_link",
+            "world")
 
     point = Point()
     point = ps.pose.position
@@ -51,8 +53,10 @@ def callback_qt(data):
 if __name__ == "__main__":
     rospy.init_node('lps_ekf_bridge')
 
-    pose_pub = rospy.Publisher(rospy.get_namespace() + "pose", PoseStamped, queue_size=10)
-    position_pub = rospy.Publisher(rospy.get_namespace() + "position", Point, queue_size=10)
+    pose_pub = rospy.Publisher(rospy.get_namespace() + "pose",
+            PoseStamped, queue_size=10)
+    position_pub = rospy.Publisher(rospy.get_namespace() + "position",
+            Point, queue_size=10)
 
     # Set anchor position according to the position setup in ROS
     rospy.wait_for_service('update_params')
@@ -62,9 +66,9 @@ if __name__ == "__main__":
 
     n_anchors = rospy.get_param("n_anchors")
     for i in range(n_anchors):
-        position = rospy.get_param("anchor{}_pos".format(i))
+        position = rospy.get_param(rospy.get_namespace()+"anchor{}_pos".format(i))
         rospy.loginfo("Anchor {} at {}".format(i, position))
-        name = "anchorpos/anchor{}".format(i)
+        name = rospy.get_namespace()+"anchorpos/anchor{}".format(i)
         rospy.set_param(name + "x", position[0])
         rospy.set_param(name + "y", position[1])
         rospy.set_param(name + "z", position[2])

--- a/scripts/lps_ekf_bridge.py
+++ b/scripts/lps_ekf_bridge.py
@@ -4,33 +4,56 @@
 # Crazyflie internal EKF instead of calculating the estimate
 
 import rospy
+from geometry_msgs.msg import PoseStamped
 from geometry_msgs.msg import Point
 
 import tf
 
 from crazyflie_driver.msg import GenericLogData
 
+ps = PoseStamped()
+ps.pose.orientation.w = 1
+ps.pose.orientation.x = 0
+ps.pose.orientation.y = 0
+ps.pose.orientation.z = 0
+ps.pose.position.x = 0
+ps.pose.position.y = 0
+ps.pose.position.z = 0
 
-def callback(data):
-    pt = Point()
-    pt.x = data.values[0]
-    pt.y = data.values[1]
-    pt.z = data.values[2]
+def callback_pos(data):
+    ps.pose.position.x = data.values[0]
+    ps.pose.position.y = data.values[1]
+    ps.pose.position.z = data.values[2]
+    ps.header.frame_id = "/world"
+    ps.header.stamp = rospy.Time.now()
 
-    position_pub.publish(pt)
+    pose_pub.publish(ps)
 
     br = tf.TransformBroadcaster()
-    br.sendTransform((pt.x, pt.y, pt.z),
-                     tf.transformations.quaternion_from_euler(0, 0, 0),
+    br.sendTransform((ps.pose.position.x, ps.pose.position.y, ps.pose.position.z),
+                     (ps.pose.orientation.x, ps.pose.orientation.y,
+                         ps.pose.orientation.z, ps.pose.orientation.w),
                      rospy.Time.now(),
                      rospy.get_namespace() + "base_link",
                      "world")
 
+    point = Point()
+    point = ps.pose.position
+    position_pub.publish(point)
+
+def callback_qt(data):
+    ps.pose.orientation.w = data.values[0]
+    ps.pose.orientation.x = data.values[1]
+    ps.pose.orientation.y = data.values[2]
+    ps.pose.orientation.z = data.values[3]
+
 if __name__ == "__main__":
     rospy.init_node('lps_ekf_bridge')
 
-    position_pub = rospy.Publisher("crazyflie_position", Point, queue_size=10)
+    pose_pub = rospy.Publisher(rospy.get_namespace() + "pose", PoseStamped, queue_size=10)
+    position_pub = rospy.Publisher(rospy.get_namespace() + "position", Point, queue_size=10)
 
-    rospy.Subscriber("log_kfpos", GenericLogData, callback)
+    rospy.Subscriber("log_kfpos", GenericLogData, callback_pos)
+    rospy.Subscriber("log_kfqt", GenericLogData, callback_qt)
 
     rospy.spin()

--- a/scripts/lps_ekf_bridge.py
+++ b/scripts/lps_ekf_bridge.py
@@ -67,10 +67,9 @@ if __name__ == "__main__":
 
     n_anchors = rospy.get_param("n_anchors")
     for i in range(n_anchors):
-        position = rospy.get_param(rospy.get_namespace() +
-                                   "anchor{}_pos".format(i))
+        position = rospy.get_param("anchor{}_pos".format(i))
         rospy.loginfo("Anchor {} at {}".format(i, position))
-        name = rospy.get_namespace()+"anchorpos/anchor{}".format(i)
+        name = "anchorpos/anchor{}".format(i)
         rospy.set_param(name + "x", position[0])
         rospy.set_param(name + "y", position[1])
         rospy.set_param(name + "z", position[2])

--- a/scripts/lps_pf.py
+++ b/scripts/lps_pf.py
@@ -41,7 +41,8 @@ if __name__ == "__main__":
     anchor_positions = get_anchors_pos()
 
     pf = pfilter.ParticleFilter(200, 0.1, (10, 10, 2))
-    position_pub = rospy.Publisher(rospy.get_namespace()+"position", Point, queue_size=10)
+    position_pub = rospy.Publisher(rospy.get_namespace()+"position",
+            Point, queue_size=10)
 
     rospy.Subscriber("ranging", RangeArray, callback)
 

--- a/scripts/lps_pf.py
+++ b/scripts/lps_pf.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
 
     pf = pfilter.ParticleFilter(200, 0.1, (10, 10, 2))
     position_pub = rospy.Publisher(rospy.get_namespace()+"position",
-            Point, queue_size=10)
+                                   Point, queue_size=10)
 
     rospy.Subscriber("ranging", RangeArray, callback)
 

--- a/scripts/lps_pf.py
+++ b/scripts/lps_pf.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
     anchor_positions = get_anchors_pos()
 
     pf = pfilter.ParticleFilter(200, 0.1, (10, 10, 2))
-    position_pub = rospy.Publisher("crazyflie_position", Point, queue_size=10)
+    position_pub = rospy.Publisher(rospy.get_namespace()+"position", Point, queue_size=10)
 
     rospy.Subscriber("ranging", RangeArray, callback)
 

--- a/scripts/lps_viz.py
+++ b/scripts/lps_viz.py
@@ -78,10 +78,10 @@ if __name__ == "__main__":
 
     anchors_positions = get_anchors_pos()
 
-    anchors_pub = rospy.Publisher("anchors_markers", MarkerArray, queue_size=1,
-                                  latch=True)
-    tag_pub = rospy.Publisher(rospy.get_namespace()+"marker", Marker, queue_size=1,
-                              latch=True)
+    anchors_pub = rospy.Publisher("anchors_markers",
+            MarkerArray, queue_size=1, latch=True)
+    tag_pub = rospy.Publisher(rospy.get_namespace()+"marker",
+            Marker, queue_size=1, latch=True)
 
     rospy.Subscriber(rospy.get_namespace()+"position", Point, callback)
 

--- a/scripts/lps_viz.py
+++ b/scripts/lps_viz.py
@@ -80,12 +80,12 @@ if __name__ == "__main__":
 
     anchors_pub = rospy.Publisher("anchors_markers", MarkerArray, queue_size=1,
                                   latch=True)
-    tag_pub = rospy.Publisher("crazyflie_marker", Marker, queue_size=1,
+    tag_pub = rospy.Publisher(rospy.get_namespace()+"marker", Marker, queue_size=1,
                               latch=True)
 
-    rospy.Subscriber("crazyflie_position", Point, callback)
+    rospy.Subscriber(rospy.get_namespace()+"position", Point, callback)
 
     publish_anchors(anchors_pub, anchors_positions)
-    publish_copter(tag_pub, [0.3, 1.1, 0.4])
+    publish_copter(tag_pub, [0, 0, 0])
 
     rospy.spin()

--- a/scripts/lps_viz.py
+++ b/scripts/lps_viz.py
@@ -78,10 +78,10 @@ if __name__ == "__main__":
 
     anchors_positions = get_anchors_pos()
 
-    anchors_pub = rospy.Publisher("anchors_markers",
-            MarkerArray, queue_size=1, latch=True)
-    tag_pub = rospy.Publisher(rospy.get_namespace()+"marker",
-            Marker, queue_size=1, latch=True)
+    anchors_pub = rospy.Publisher("anchors_markers", MarkerArray,
+                                  queue_size=1, latch=True)
+    tag_pub = rospy.Publisher(rospy.get_namespace()+"marker", Marker,
+                              queue_size=1, latch=True)
 
     rospy.Subscriber(rospy.get_namespace()+"position", Point, callback)
 

--- a/scripts/pos_zmq.py
+++ b/scripts/pos_zmq.py
@@ -14,7 +14,7 @@ def callback(data):
 if __name__ == "__main__":
     rospy.init_node('pos_zmq')
 
-    rospy.Subscriber("crazyflie_position", Point, callback)
+    rospy.Subscriber(rospy.get_namespace()+"position", Point, callback)
 
     context = zmq.Context()
     pos_socket = context.socket(zmq.PUSH)


### PR DESCRIPTION
In conjunction with the commit in the crazyflie-firmware repo, https://github.com/bitcraze/crazyflie-firmware/commit/ff15bbe9a4d30e6335d02528c26fa37d33097df2, this will give a full orientation for attaching sensors to the crazyflie in ROS.

Also adds namespaces to avoid publishing conflicts with multiple crazyflies.
