### PR TITLE
Anchor pos viz

### DIFF
--- a/launch/dwm_loc_ekf_hover.launch
+++ b/launch/dwm_loc_ekf_hover.launch
@@ -7,22 +7,20 @@
   <arg name="y" default="2.3" />
   <arg name="z" default="1" />
 
-  <node name="log_range" pkg="bitcraze_lps_estimator" type="log_range.py" />
-
   <param name="robot_description" command="$(find xacro)/xacro.py $(find crazyflie_description)/urdf/crazyflie2.urdf.xacro" />
   <node name="rviz" pkg="rviz" type="rviz"
         args="-d $(find bitcraze_lps_estimator)/data/rvizconfig_with_goal.rviz"/>
 
 
-  <group ns="crazyflie">
-    <rosparam command="load" file="$(find bitcraze_lps_estimator)/data/anchor_pos.yaml" />
+  <rosparam command="load" file="$(find bitcraze_lps_estimator)/data/anchor_pos.yaml" />
 
+  <group ns="crazyflie">
     <node pkg="crazyflie_driver" type="crazyflie_add" name="crazyflie_add" output="screen">
       <param name="uri" value="$(arg uri)" />
       <param name="tf_prefix" value="crazyflie" />
       <rosparam>
         genericLogTopics: ["log_kfpos", "log_kfqt", "log_ranges"]
-        genericLogTopicFrequencies: [30, 30, 30]
+        genericLogTopicFrequencies: [30, 30, 50]
         genericLogTopic_log_kfpos_Variables: ["kalman.stateX", "kalman.stateY", "kalman.stateZ"]
         genericLogTopic_log_kfqt_Variables: ["kalman.q0", "kalman.q1", "kalman.q2", "kalman.q3"]
         genericLogTopic_log_ranges_Variables: ["ranging.distance1", "ranging.distance2", "ranging.distance3", "ranging.distance4", "ranging.distance5", "ranging.distance6", "ranging.state"]
@@ -50,6 +48,8 @@
     <node name="lps_efk_bridge" pkg="bitcraze_lps_estimator" type="lps_ekf_bridge.py" output="screen"/>
 
     <node name="lps_viz" pkg="bitcraze_lps_estimator" type="lps_viz.py" />
+
+    <node name="log_range" pkg="bitcraze_lps_estimator" type="log_range.py" />
 
   </group>
 

--- a/launch/dwm_loc_ekf_multi_hover.launch
+++ b/launch/dwm_loc_ekf_multi_hover.launch
@@ -20,8 +20,6 @@
 
 
   <group ns="crazyflie0">
-    <rosparam command="load" file="$(find bitcraze_lps_estimator)/data/anchor_pos.yaml" />
-
     <node pkg="crazyflie_driver" type="crazyflie_add" name="crazyflie_add" output="screen">
       <param name="uri" value="$(arg uri0)" />
       <param name="tf_prefix" value="crazyflie0" />
@@ -60,8 +58,6 @@
   </group>
 
   <group ns="crazyflie1">
-    <rosparam command="load" file="$(find bitcraze_lps_estimator)/data/anchor_pos.yaml" />
-
     <node pkg="crazyflie_driver" type="crazyflie_add" name="crazyflie_add" output="screen">
       <param name="uri" value="$(arg uri1)" />
       <param name="tf_prefix" value="crazyflie1" />

--- a/launch/dwm_loc_ekf_swarm_hover.launch
+++ b/launch/dwm_loc_ekf_swarm_hover.launch
@@ -35,8 +35,6 @@
 
 
   <group ns="crazyflie0">
-    <rosparam command="load" file="$(find bitcraze_lps_estimator)/data/anchor_pos.yaml" />
-
     <node pkg="crazyflie_driver" type="crazyflie_add" name="crazyflie_add" output="screen">
       <param name="uri" value="$(arg uri0)" />
       <param name="tf_prefix" value="crazyflie0" />
@@ -75,8 +73,6 @@
   </group>
 
   <group ns="crazyflie1">
-    <rosparam command="load" file="$(find bitcraze_lps_estimator)/data/anchor_pos.yaml" />
-
     <node pkg="crazyflie_driver" type="crazyflie_add" name="crazyflie_add" output="screen">
       <param name="uri" value="$(arg uri1)" />
       <param name="tf_prefix" value="crazyflie1" />
@@ -116,8 +112,6 @@
 
 
   <group ns="crazyflie2">
-    <rosparam command="load" file="$(find bitcraze_lps_estimator)/data/anchor_pos.yaml" />
-
     <node pkg="crazyflie_driver" type="crazyflie_add" name="crazyflie_add" output="screen">
       <param name="uri" value="$(arg uri2)" />
       <param name="tf_prefix" value="crazyflie2" />
@@ -156,8 +150,6 @@
   </group>
 
   <group ns="crazyflie3">
-    <rosparam command="load" file="$(find bitcraze_lps_estimator)/data/anchor_pos.yaml" />
-
     <node pkg="crazyflie_driver" type="crazyflie_add" name="crazyflie_add" output="screen">
       <param name="uri" value="$(arg uri3)" />
       <param name="tf_prefix" value="crazyflie3" />
@@ -196,8 +188,6 @@
   </group>
 
   <group ns="crazyflie4">
-    <rosparam command="load" file="$(find bitcraze_lps_estimator)/data/anchor_pos.yaml" />
-
     <node pkg="crazyflie_driver" type="crazyflie_add" name="crazyflie_add" output="screen">
       <param name="uri" value="$(arg uri4)" />
       <param name="tf_prefix" value="crazyflie4" />

--- a/scripts/anchorpos.py
+++ b/scripts/anchorpos.py
@@ -3,10 +3,10 @@ import rospy
 
 
 def get_anchors_pos():
-    n = rospy.get_param("n_anchors")
+    n = rospy.get_param("/n_anchors")
     anchors_pos = {}
 
     for i in range(n):
-        anchors_pos[i] = rospy.get_param("anchor{}_pos".format(i))
+        anchors_pos[i] = rospy.get_param("/anchor{}_pos".format(i))
 
     return anchors_pos

--- a/scripts/log_range.py
+++ b/scripts/log_range.py
@@ -4,15 +4,15 @@
 # range0..5, status
 import rospy
 from bitcraze_lps_estimator.msg import RangeArray
-from crazyflie_driver.msg import GenericLogData
+from std_msgs.msg import Float32MultiArray
 
 
 def callback(data):
     ranging = RangeArray()
 
-    ranging.ranges = data.values[:6]
+    ranging.ranges = data.data[:6]
 
-    state = int(data.values[6])
+    state = int(data.data[6])
     valid = [False] * 6
     for i in range(6):
         valid[i] = (state & (1 << i)) != 0
@@ -26,6 +26,6 @@ if __name__ == "__main__":
     ranging_pub = rospy.Publisher("ranging", RangeArray, queue_size=10)
 
     rospy.Subscriber(rospy.get_namespace()+"log_ranges",
-                     GenericLogData, callback)
+                     Float32MultiArray, callback)
 
     rospy.spin()

--- a/scripts/log_range.py
+++ b/scripts/log_range.py
@@ -5,7 +5,19 @@
 import rospy
 from bitcraze_lps_estimator.msg import RangeArray
 from std_msgs.msg import Float32MultiArray
+from visualization_msgs.msg import MarkerArray, Marker
+from geometry_msgs.msg import PoseStamped, Vector3, Point
 
+from anchorpos import get_anchors_pos
+
+import math
+
+anchorpos = []
+last_pos = PoseStamped()
+
+def pose_cb(data):
+    global last_pos
+    last_pos = data
 
 def callback(data):
     ranging = RangeArray()
@@ -20,12 +32,69 @@ def callback(data):
 
     ranging_pub.publish(ranging)
 
+    marker_array = MarkerArray()
+    for i in range(6):
+        marker = Marker()
+        marker.header.frame_id = "/world"
+        marker.id = i+40
+        marker.type = 4
+        marker.lifetime = rospy.Duration(1.0)
+        marker.ns = rospy.get_namespace()
+        marker.action = 0
+        p = Point()
+        p.x = anchorpos[i][0]
+        p.y = anchorpos[i][1]
+        p.z = anchorpos[i][2]
+        marker.points.append(p)
+        dir_vect = Vector3()
+        global last_pos
+        dir_vect.x = last_pos.pose.position.x - anchorpos[i][0]
+        dir_vect.y = last_pos.pose.position.y - anchorpos[i][1]
+        dir_vect.z = last_pos.pose.position.z - anchorpos[i][2]
+        mag = math.sqrt(dir_vect.x**2 + dir_vect.y**2 + dir_vect.z**2)
+        dir_vect.x /= mag
+        dir_vect.y /= mag
+        dir_vect.z /= mag
+        #print(ranging.ranges[i], anchorpos[i])
+        #marker.pose.position.x = ranging.ranges[i]*dir_vect.x + anchorpos[i][0]
+        #marker.pose.position.y = ranging.ranges[i]*dir_vect.y + anchorpos[i][1]
+        #marker.pose.position.z = ranging.ranges[i]*dir_vect.z + anchorpos[i][2]
+        #marker.pose.orientation.x = 0
+        #marker.pose.orientation.y = 0
+        #marker.pose.orientation.z = 0
+        #marker.pose.orientation.w = 1
+        dist = Point()
+        dist.x = ranging.ranges[i]*dir_vect.x + anchorpos[i][0]
+        dist.y = ranging.ranges[i]*dir_vect.y + anchorpos[i][1]
+        dist.z = ranging.ranges[i]*dir_vect.z + anchorpos[i][2]
+        marker.scale.x = 0.005
+        if '0' in marker.ns:
+            marker.color.r = 1
+        elif '1' in marker.ns:
+            marker.color.g = 1
+        elif '2' in marker.ns:
+            marker.color.b = 1
+        marker.color.a = 0.5
+        marker.points.append(dist)
+        marker_array.markers.append(marker)
+
+    range_paths.publish(marker_array)
+
+
 if __name__ == "__main__":
     rospy.init_node('log_range')
 
     ranging_pub = rospy.Publisher("ranging", RangeArray, queue_size=10)
 
-    rospy.Subscriber(rospy.get_namespace()+"log_ranges",
+    rospy.Subscriber("log_ranges",
                      Float32MultiArray, callback)
+
+    anchor_dict = get_anchors_pos()
+    for name in anchor_dict:
+        anchorpos.append((anchor_dict[name][0], anchor_dict[name][1], anchor_dict[name][2]))
+
+    rospy.Subscriber("pose", PoseStamped, pose_cb)
+
+    range_paths = rospy.Publisher(rospy.get_namespace() + "range_paths", MarkerArray, queue_size=10)
 
     rospy.spin()

--- a/scripts/log_range.py
+++ b/scripts/log_range.py
@@ -20,6 +20,7 @@ def pose_cb(data):
     last_pos = data
 
 def callback(data):
+    # Update the range array
     ranging = RangeArray()
 
     ranging.ranges = data.data[:6]
@@ -32,22 +33,24 @@ def callback(data):
 
     ranging_pub.publish(ranging)
 
+    # Create the ranging lines
     marker_array = MarkerArray()
     for i in range(6):
         marker = Marker()
         marker.header.frame_id = "/world"
-        marker.id = i+40
-        marker.type = 4
+        marker.id = i+40 # Pick arbirary id
+        marker.type = Marker.LINE_STRIP  # Use line marker type
         marker.lifetime = rospy.Duration(1.0)
         marker.ns = rospy.get_namespace()
         marker.action = 0
-        p = Point()
+        p = Point() # Start line at marker
         p.x = anchorpos[i][0]
         p.y = anchorpos[i][1]
         p.z = anchorpos[i][2]
         marker.points.append(p)
-        dir_vect = Vector3()
         global last_pos
+        # Create normalized direction vector
+        dir_vect = Vector3()
         dir_vect.x = last_pos.pose.position.x - anchorpos[i][0]
         dir_vect.y = last_pos.pose.position.y - anchorpos[i][1]
         dir_vect.z = last_pos.pose.position.z - anchorpos[i][2]
@@ -55,25 +58,15 @@ def callback(data):
         dir_vect.x /= mag
         dir_vect.y /= mag
         dir_vect.z /= mag
-        #print(ranging.ranges[i], anchorpos[i])
-        #marker.pose.position.x = ranging.ranges[i]*dir_vect.x + anchorpos[i][0]
-        #marker.pose.position.y = ranging.ranges[i]*dir_vect.y + anchorpos[i][1]
-        #marker.pose.position.z = ranging.ranges[i]*dir_vect.z + anchorpos[i][2]
-        #marker.pose.orientation.x = 0
-        #marker.pose.orientation.y = 0
-        #marker.pose.orientation.z = 0
-        #marker.pose.orientation.w = 1
+        # Apply range for the anchor to the direction vector
         dist = Point()
         dist.x = ranging.ranges[i]*dir_vect.x + anchorpos[i][0]
         dist.y = ranging.ranges[i]*dir_vect.y + anchorpos[i][1]
         dist.z = ranging.ranges[i]*dir_vect.z + anchorpos[i][2]
         marker.scale.x = 0.005
-        if '0' in marker.ns:
-            marker.color.r = 1
-        elif '1' in marker.ns:
-            marker.color.g = 1
-        elif '2' in marker.ns:
-            marker.color.b = 1
+        marker.color.r = rospy.get_param("red",   1)
+        marker.color.g = rospy.get_param("green", 0)
+        marker.color.b = rospy.get_param("blue",  0)
         marker.color.a = 0.5
         marker.points.append(dist)
         marker_array.markers.append(marker)

--- a/scripts/log_range.py
+++ b/scripts/log_range.py
@@ -15,9 +15,11 @@ import math
 anchorpos = []
 last_pos = PoseStamped()
 
+
 def pose_cb(data):
     global last_pos
     last_pos = data
+
 
 def callback(data):
     # Update the range array
@@ -38,17 +40,20 @@ def callback(data):
     for i in range(6):
         marker = Marker()
         marker.header.frame_id = "/world"
-        marker.id = i+40 # Pick arbirary id
-        marker.type = Marker.LINE_STRIP  # Use line marker type
+        marker.id = i+40
+        marker.type = Marker.LINE_STRIP
         marker.lifetime = rospy.Duration(1.0)
         marker.ns = rospy.get_namespace()
         marker.action = 0
-        p = Point() # Start line at marker
+
+        # Start line at marker
+        p = Point()
         p.x = anchorpos[i][0]
         p.y = anchorpos[i][1]
         p.z = anchorpos[i][2]
         marker.points.append(p)
         global last_pos
+
         # Create normalized direction vector
         dir_vect = Vector3()
         dir_vect.x = last_pos.pose.position.x - anchorpos[i][0]
@@ -58,6 +63,7 @@ def callback(data):
         dir_vect.x /= mag
         dir_vect.y /= mag
         dir_vect.z /= mag
+
         # Apply range for the anchor to the direction vector
         dist = Point()
         dist.x = ranging.ranges[i]*dir_vect.x + anchorpos[i][0]
@@ -84,10 +90,13 @@ if __name__ == "__main__":
 
     anchor_dict = get_anchors_pos()
     for name in anchor_dict:
-        anchorpos.append((anchor_dict[name][0], anchor_dict[name][1], anchor_dict[name][2]))
+        anchorpos.append((anchor_dict[name][0],
+                          anchor_dict[name][1],
+                          anchor_dict[name][2]))
 
     rospy.Subscriber("pose", PoseStamped, pose_cb)
 
-    range_paths = rospy.Publisher(rospy.get_namespace() + "range_paths", MarkerArray, queue_size=10)
+    range_paths = rospy.Publisher(rospy.get_namespace()+"range_paths",
+                                  MarkerArray, queue_size=10)
 
     rospy.spin()

--- a/scripts/lps_ekf_bridge.py
+++ b/scripts/lps_ekf_bridge.py
@@ -62,7 +62,7 @@ if __name__ == "__main__":
     rospy.wait_for_service('update_params')
     update_params = rospy.ServiceProxy('update_params', UpdateParams)
 
-    enabled = rospy.get_param("anchor_pos.enable")
+    enabled = rospy.get_param("anchorpos/enable")
     if enabled == False:
         rospy.loginfo("Setting anchor position ...")
         n_anchors = rospy.get_param("n_anchors")

--- a/scripts/lps_ekf_bridge.py
+++ b/scripts/lps_ekf_bridge.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     update_params = rospy.ServiceProxy('update_params', UpdateParams)
 
     enabled = rospy.get_param("anchorpos/enable")
-    if enabled == False:
+    if not enabled:
         rospy.loginfo("Setting anchor position ...")
         n_anchors = rospy.get_param("n_anchors")
         for i in range(n_anchors):

--- a/scripts/lps_ekf_bridge.py
+++ b/scripts/lps_ekf_bridge.py
@@ -7,10 +7,9 @@ import rospy
 from geometry_msgs.msg import PoseStamped
 from geometry_msgs.msg import Point
 from crazyflie_driver.srv import UpdateParams
+from std_msgs.msg import Float32MultiArray
 
 import tf
-
-from crazyflie_driver.msg import GenericLogData
 
 ps = PoseStamped()
 ps.pose.orientation.w = 1
@@ -23,9 +22,9 @@ ps.pose.position.z = 0
 
 
 def callback_pos(data):
-    ps.pose.position.x = data.values[0]
-    ps.pose.position.y = data.values[1]
-    ps.pose.position.z = data.values[2]
+    ps.pose.position.x = data.data[0]
+    ps.pose.position.y = data.data[1]
+    ps.pose.position.z = data.data[2]
     ps.header.frame_id = "/world"
     ps.header.stamp = rospy.Time.now()
 
@@ -46,10 +45,10 @@ def callback_pos(data):
 
 
 def callback_qt(data):
-    ps.pose.orientation.w = data.values[0]
-    ps.pose.orientation.x = data.values[1]
-    ps.pose.orientation.y = data.values[2]
-    ps.pose.orientation.z = data.values[3]
+    ps.pose.orientation.w = data.data[0]
+    ps.pose.orientation.x = data.data[1]
+    ps.pose.orientation.y = data.data[2]
+    ps.pose.orientation.z = data.data[3]
 
 if __name__ == "__main__":
     rospy.init_node('lps_ekf_bridge')
@@ -63,20 +62,21 @@ if __name__ == "__main__":
     rospy.wait_for_service('update_params')
     update_params = rospy.ServiceProxy('update_params', UpdateParams)
 
-    rospy.loginfo("Setting anchor position ...")
+    enabled = rospy.get_param("anchor_pos.enable")
+    if enabled == False:
+        rospy.loginfo("Setting anchor position ...")
+        n_anchors = rospy.get_param("n_anchors")
+        for i in range(n_anchors):
+            position = rospy.get_param("anchor{}_pos".format(i))
+            rospy.loginfo("Anchor {} at {}".format(i, position))
+            name = "anchorpos/anchor{}".format(i)
+            rospy.set_param(name + "x", position[0])
+            rospy.set_param(name + "y", position[1])
+            rospy.set_param(name + "z", position[2])
+            update_params([name + 'x', name + 'y', name + 'z'])
 
-    n_anchors = rospy.get_param("n_anchors")
-    for i in range(n_anchors):
-        position = rospy.get_param("anchor{}_pos".format(i))
-        rospy.loginfo("Anchor {} at {}".format(i, position))
-        name = "anchorpos/anchor{}".format(i)
-        rospy.set_param(name + "x", position[0])
-        rospy.set_param(name + "y", position[1])
-        rospy.set_param(name + "z", position[2])
-        update_params([name + 'x', name + 'y', name + 'z'])
-
-    rospy.Subscriber("log_kfpos", GenericLogData, callback_pos)
-    rospy.Subscriber("log_kfqt", GenericLogData, callback_qt)
+    rospy.Subscriber("log_kfpos", Float32MultiArray, callback_pos)
+    rospy.Subscriber("log_kfqt", Float32MultiArray, callback_qt)
     if rospy.has_param("anchorpos/enable"):
         rospy.set_param("anchorpos/enable", 1)
         update_params(["anchorpos/enable"])


### PR DESCRIPTION
This PR depends on whoenig/crazyflie_ros#49 and does the following:
* Change the anchorpos parameters to be only in the global namespace
* Change log type to a Float32MultiArray which allows much easier plotting of data (in rqt_plot for example), as it is encoded as floats instead of string of a literal list
* Only send anchor positions if it isn't already enabled on the crazyflie
* Add a visualization for TWR/TDMA to show the range estimate from each anchor

Should address #6.
